### PR TITLE
Central Command Department

### DIFF
--- a/Resources/Locale/en-US/Floof/job/department-desc.ftl
+++ b/Resources/Locale/en-US/Floof/job/department-desc.ftl
@@ -1,0 +1,1 @@
+department-CentComm-description = Oversee the sector, reprimand the captain, and ensure the station is following Nanotrasen policy.

--- a/Resources/Locale/en-US/Floof/job/department.ftl
+++ b/Resources/Locale/en-US/Floof/job/department.ftl
@@ -1,0 +1,1 @@
+department-CentralCommand = Central Command

--- a/Resources/Prototypes/Floof/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Floof/Roles/Jobs/departments.yml
@@ -1,0 +1,8 @@
+- type: department
+  id: CentralCommand
+  description: department-CentComm-description
+  color: "#009100"
+  roles:
+    - CentralCommandOfficial
+  primary: false
+  weight: 1000 # Heavy lies the crown on the king's head

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -41,7 +41,7 @@
   color: "#334E6D"
   roles:
   - Captain
-  - CentralCommandOfficial
+  # - CentralCommandOfficial | Floof - M3739 - #727 - Moved to it's own department
   - ChiefEngineer
   - ChiefMedicalOfficer
   - HeadOfPersonnel


### PR DESCRIPTION
Greetings,

I'd figure I help ya out a bit by separating the Central Commander from the Command department, giving it a new home in the Central Command department. The department has a weight of a 1000 to ensure it always shows on top of the manifests.

![image](https://github.com/user-attachments/assets/a0da6fcf-4e7f-4e64-a315-62ca114eba94)
![image](https://github.com/user-attachments/assets/0b0f427d-5d11-48b1-86cd-cb6ffdb07439)
